### PR TITLE
moved ArangoDB to document and graph model

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,11 @@ Pipes and the C libhdfs APIs, that allows to write full-fledged  MapReduce appli
 <td width="20%"><a href="http://www.rethinkdb.com/">1. RethinkDB site</a></td>
 </tr>
 <tr>
+<td width="20%">ArangoDB</td>
+<td>An open-source database with a flexible data model for documents, graphs, and key-values. Build high performance applications using a convenient sql-like query language or JavaScript extensions.</td>
+<td width="20%"><a href="https://www.arangodb.org/">1. ArangoDB site</a></td>
+</tr>
+<tr>
 <th colspan="3" style="background-color:#0099FF;">Key-value Data Model</th>
 </tr>
 <tr>
@@ -270,6 +275,11 @@ In its outer layer, the Redis data model is a dictionary which maps keys to valu
 </tr>
 <tr>
 <th colspan="3" style="background-color:#0099FF;">Graph Data Model</th>
+</tr>
+<tr>
+<td width="20%">ArangoDB</td>
+<td>An open-source database with a flexible data model for documents, graphs, and key-values. Build high performance applications using a convenient sql-like query language or JavaScript extensions.</td>
+<td width="20%"><a href="https://www.arangodb.org/">1. ArangoDB site</a></td>
 </tr>
 
 <tr>
@@ -305,11 +315,6 @@ HandlerSocket can be much faster than mysqld/libmysql in some cases because it h
 <td width="20%">SenseiDB</td>
 <td>Open-source, distributed, realtime, semi-structured database. Some Features: Full-text search, Fast realtime updates, Structured and faceted search, BQL: SQL-like query language, Fast key-value lookup, High performance under concurrent heavy update and query volumes, Hadoop integration</td>
 <td width="20%"><a href="http://senseidb.com/">1. SenseiDB site</a></td>
-</tr>
-<tr>
-<td width="20%">ArangoDB</td>
-<td>An open-source database with a flexible data model for documents, graphs, and key-values. Build high performance applications using a convenient sql-like query language or JavaScript extensions.</td>
-<td width="20%"><a href="https://www.arangodb.org/">1. ArangoDB site</a></td>
 </tr>
 <tr>
 <td width="20%">Sky</td>


### PR DESCRIPTION
ArangoDB is a multi-model database, with the focus on Documents and Graphs. It has a SQL-like syntax, but it does not support standard SQL. Therefore, I believe, the correct category would be "NoSQL Databases" > "Multi-Model". I did not dare to create a new category, therefore I moved it to "Document Model" and "Graph Model" instead.
