### PR TITLE
Argus: coordinated data security policy for hadoop

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,6 +646,13 @@ Twitter has recently released a Hadoop-Storm Hybrid called “Summingbird.” Su
 <td> System that provides a single point of secure access for Apache Hadoop clusters. The goal is to simplify Hadoop security for both users (i.e. who access the cluster data and execute jobs) and operators (i.e. who control access and manage the cluster). The Gateway runs as a server (or cluster of servers) that serve one or more Hadoop clusters.</td>
 <td width="20%">TODO</td>
 </tr>
+<tr>
+  <td width="20%">Apache Argus</td>
+  <td> Apache Argus deliver comprehensive approach to central security policy administration across the core enterprise security requirements of authentication, authorization, accounting and data protection. It extends baseline features for coordinated enforcement across Hadoop workloads from batch, interactive SQL and real–time and leverages the extensible architecture to apply policies consistently against additional Hadoop ecosystem components (beyond HDFS, Hive, and HBase) including Storm, Solr, Spark, and more. </td>
+  <td width="20%"><a href="http://wiki.apache.org/incubator/ArgusProposal">1. Argus Apache incubator proposal</a>
+    <br><a href="http://hortonworks.com/blog/announcing-apache-argus-call-arms/">2. Hortonworks announcement of Apache Argus</a>
+  </td>
+</tr>
 
 <tr>
 <th colspan="3">System Deployment</th>


### PR DESCRIPTION
Argus engineers found hadoop ecosystem table very useful and asked to include Apache Argus to hadoop security components.
