### PR TITLE
Updated Apache Nifi's URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@ Twitter has recently released a Hadoop-Storm Hybrid called “Summingbird.” Su
 <tr>
 <td width="20%">Apache NiFi</td>
 <td>Apache NiFi is a dataflow system that is currently under incubation at the Apache Software Foundation. NiFi is based on the concepts of flow-based programming and is highly configurable. NiFi uses a component based extension model to rapidly add capabilities to complex dataflows. Out of the box NiFi has several extensions for dealing with file-based dataflows such as FTP, SFTP, and HTTP integration as well as integration with HDFS. One of NiFi’s unique features is a rich, web-based interface for designing, controlling, and monitoring a dataflow.</td>
-<td width="20%"><a href="https://nifi.incubator.apache.org/index.html">1. Apache NiFi</a></td>
+<td width="20%"><a href="http://nifi.apache.org/index.html">1. Apache NiFi</a></td>
 </tr>
  
 


### PR DESCRIPTION
The old link was linking to the incubator site (which was redirected to the current website).

Old URL: https://nifi.incubator.apache.org/index.html
Current URL: https://nifi.apache.org/