### PR TITLE
Update Tachyon's description to its site description.

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,23 @@ the parallel file system used by many of the world's fastest supercomputers</td>
 </tr>
 <tr>
 <td width="30%">Tachyon</td>
-<td>Tachyon is an memory distributed file system. By storing the file-system 
-    contents in the main memory of all cluster nodes, the system achieves higher
-    throughput than traditional disk-based storage systems like HDFS.</td>
+<td>Tachyon is an open source memory-centric distributed storage system enabling reliable data 
+sharing at memory-speed across cluster jobs, possibly written in different computation 
+frameworks, such as Apache Spark and Apache MapReduce. In the big data ecosystem, Tachyon lies 
+between computation frameworks or jobs, such as Apache Spark, Apache MapReduce, or Apache Flink, 
+and various kinds of storage systems, such as Amazon S3, OpenStack Swift, GlusterFS, HDFS, or 
+Ceph. Tachyon brings significant performance improvement to the stack; for example, Baidu uses 
+Tachyon to improve their data analytics performance by 30 times. Beyond performance, Tachyon 
+bridges new workloads with data stored in traditional storage systems. Users can run Tachyon 
+using its standalone cluster mode, for example on Amazon EC2, or launch Tachyon with Apache Mesos 
+or Apache Yarn. <br> 
+Tachyon is Hadoop compatible. This means that existing Spark and MapReduce programs can run on 
+top of Tachyon without any code changes. The project is open source (Apache License 2.0) and is 
+deployed at multiple companies. It is one of the fastest growing open source projects. With less 
+than three years open source history, Tachyon has attracted more than 150 contributors from over 
+50 institutions, including Alibaba, Baidu, CMU, IBM, Intel, Red Hat, Tachyon Nexus, UC Berkeley, 
+and Yahoo. The project is the storage layer of the Berkeley Data Analytics Stack (BDAS) and also 
+part of the Fedora distribution.</td>
 <td width="20%"><a href="http://tachyon-project.org/">1. Tachyon site</a>
 </tr>
 


### PR DESCRIPTION
Updates Tachyon's description to the one found on its documentation site (http://tachyon-project.org/documentation/).

I added a trailing whitespace to all the lines since that seemed to be the page's style.