### PR TITLE
Updated Trafodion entry to reflect Apache Incubation Project

### DIFF
--- a/index.html
+++ b/index.html
@@ -996,13 +996,20 @@
 	</tr>
 
 	<tr>
-	<td width="20%">Trafodion: Transactional SQL-on-HBase</td>
+	<td width="20%">Apache Trafodion</td>
 	<td>
-		Trafodion is an open source project sponsored by HP, incubated 
-		at HP Labs and HP-IT, to develop an enterprise-class SQL-on-HBase 
-		solution targeting big data transactional or operational workloads. 
+		Apache Trafodion is a webscale SQL-on-Hadoop solution enabling
+		enterprise-class transactional and operational workloads on
+		HBase. Trafodion is a native MPP ANSI SQL database engine that
+		builds on the scalability, elasticity and flexibility of HDFS and
+		HBase, extending these to provide guaranteed transactional
+		integrity for all workloads including multi-column, multi-row,
+		multi-table, and multi-server updates.
 	</td>
-	<td width="20%"><a href="https://wiki.trafodion.org/wiki/index.php/Main_Page">1. Trafodion wiki</a>
+	<td width="20%"><a href="http://trafodion.incubator.apache.org">1. Apache Trafodion website</a>
+	  <br> <a href="https://cwiki.apache.org/confluence/display/TRAFODION/Apache+Trafodion+Home">2. Apache Trafodion wiki</a>
+	  <br> <a href="https://github.com/apache/incubator-trafodion">3. Apache Trafodion GitHub Project</a>
+	  
 	</td>
 	</tr>
 	


### PR DESCRIPTION
Updated the text and links for Trafodion .  It is now an Apache
incubation project. The description and the website, wiki, and source
repository links are again correct.