### PR TITLE
Remove Apache Whirr

### DIFF
--- a/index.html
+++ b/index.html
@@ -1837,16 +1837,6 @@
 	</tr>
 
 	<tr>
-	<td width="20%">Apache Whirr</td>
-	<td>
-		Apache Whirr is a set of libraries for running cloud services. It allows you 
-		to use simple commands to boot clusters of distributed systems for testing and 
-		experimentation. Apache Whirr makes booting clusters easy.
-	</td>
-	<td width="20%">TODO</td>
-	</tr>
-
-	<tr>
 	<td width="20%">Apache Mesos</td>
 	<td>
 		Mesos is a cluster manager that provides resource sharing and isolation across 


### PR DESCRIPTION
retired as of March 18th, 2015

https://whirr.apache.org/